### PR TITLE
Fix the number of decimals in formatEnergy

### DIFF
--- a/solaredge-driver.groovy
+++ b/solaredge-driver.groovy
@@ -601,8 +601,7 @@ def updateTiles() {
 private formatEnergy(energy)
 {
   if (energy < 1000) return energy + " Wh"
-
-  if (energy < 1000000) return energy/1000 + " kWh"
-
-  return energy/1000/1000 + " MWh"
+  if (energy < 1000000) return Math.round((double) (energy/1000) * 100) / 100 + " kWh"
+  
+  return Math.round((double) (energy/1000/1000) * 100) / 100  + " MWh"
 }


### PR DESCRIPTION
I was finding the level of detail to be kind of overkill (13.123434985905 mwh as an example). This change makes sure there are only 2 decimal points after the whole number to make it work better in the dashboard.