### PR TITLE
Added Battery Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Hubitat-solaredge
 
+* 1.2.0 - Added Battery Storage
+
 * 1.1.2 - Bug fixes for updated timestamp and tile refresh.
-* 
+
 * 1.1.1 - Update to include flow direction coloring.
 
 * 1.1.0 - Update with improved settings and extra endpoint that includes power flow direction.


### PR DESCRIPTION
 + Tweaked description in the comment at the top of the driver to include battery in the list of details retrieved.  I left the description in the driver definition section as-is
 + version() - Adjusted the version number returned from 1.1.2 to 1.2.0, seeing this as a new feature, but not a breaking change
 + MetaData
   + Added Battery Capability and battery attribute references
   + Added three new "storage" attributes, named in line with terms in the JSON returned by the flow API call, storage_status, storage_power and storage_charge
      + Note, the battery attribute is a duplication of the storage_charge attribute.  I decided to keep to the same names from the API call while adherring to the Battery capability
 + querySitePowerFlowEndpoint() method
   + Added new storage and battery attributes to the sendEvent calls in the delayBetween section
   + Updated state.flow_direction logic to include power being provided by the battery when determining if more is being provided by the grid
 + updateTiles() method - added storage_power to flow tile
 + Some minor code formatting changes (spaces etc)
 + Added the exception object e to one of the logs for an Exception occurring
 + Updated ChangeLog to include version 1.2.0